### PR TITLE
fix(svg): enable camelCaseSvgKeywords to avoid 14.3.0 breaking change

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,11 @@ module.exports = {
         /^ng-/
       ]
     }],
+    'value-keyword-case': ['lower', {
+      // Expect SVG keywords to be camel case.
+      // https://stylelint.io/user-guide/rules/list/value-keyword-case/#camelcasesvgkeywords-true--false-default-false
+      camelCaseSvgKeywords: true
+    }],
 
     // Order plugin rules
     "order/order": [


### PR DESCRIPTION
[stylelint 14.3.0](https://github.com/stylelint/stylelint/releases/tag/14.3.0) fixed an issue checking the case of SVG attributes. This fix was a breaking change, as it changed the expectation for casing of these attributes.

For example, OpenSphere uses:
```
shape-rendering: crispEdges;
```

In 14.3.0, this is expected to be:
```
shape-rendering: crispedges;
```

Rather than change styles in OpenSphere, we will enable this new option to preserve the existing CSS behavior.